### PR TITLE
Added a simple persistent bookmarks feature

### DIFF
--- a/platform/x11/pdfapp.c
+++ b/platform/x11/pdfapp.c
@@ -227,6 +227,7 @@ void pdfapp_open(pdfapp_t *app, char *filename, int reload)
 	  int res = fread(app->marks,sizeof(int),10,fbm);
 	  //printf("read %d items\n",res);
 	  //int i; for(i=0;i<10;i++) printf("%d",app->marks[i]);
+	  fclose(fbm);
 	}
 #endif
 }


### PR DESCRIPTION
About two years ago I added a simple feature that allows bookmarks to be saved near the original file, and used in successive sessions.

Implementation is simple: every time a mark is created, the entire array of bookmarks is saved alongside the original file, named similarly, with a .bmk extension.  Every time a file is opened, the bookmark file is loaded.  Failure is tolerated (and expected on read-only systems, etc), resulting in (mostly) 'normal' non-persistent bookmarks.  If no bookmarks are created during a session, no file is written.

The changes are contained in a few lines in platform/x11/pdfapp.c and for your convenience, the two persistent bookmark codesnippets are surrounded by #ifdef PERSIST_BOOKMARKS marks.  It may be worth it to attach this feature to a command-line switch - although little harm comes from having it on all the time.

I haven't looked into what it would take to add this to non-x11 platforms.

Thank you for your consideration - I've been using this feature with great joy and hope that others may too.